### PR TITLE
Update Compile-ALProjectTree.ps1

### DIFF
--- a/Compile-ALProjectTree.ps1
+++ b/Compile-ALProjectTree.ps1
@@ -58,14 +58,20 @@ function Compile-ALProjectTree
         } else {
             Compile-AppInNavContainer -containerName $ContainerName -appProjectFolder $AppPath -appOutputFolder $PackagesPath -appSymbolsFolder $PackagesPath | Out-Null
         }
-
+        
+        if (Test-Path "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\SignTool.exe") {
+            $SignTool = (get-item "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\SignTool.exe").FullName
+        } else {
+            throw "Couldn't find SignTool.exe, please install Windows SDK from https://go.microsoft.com/fwlink/p/?LinkID=2023014"
+        }
+        
         if ($CertPath) {
             if ($CertPwd) {
                 Write-Host "Signing the app with $CertPath and password..."
-                SignTool sign /f $CertPath /p $CertPwd /t http://timestamp.verisign.com/scripts/timestamp.dll $AppFileName
+                $SignTool sign /f $CertPath /p $CertPwd /t http://timestamp.verisign.com/scripts/timestamp.dll $AppFileName
             } else {
                 Write-Host "Signing the app with $CertPath..."
-                SignTool sign /f $CertPath /t http://timestamp.verisign.com/scripts/timestamp.dll $AppFileName
+                $SignTool sign /f $CertPath /t http://timestamp.verisign.com/scripts/timestamp.dll $AppFileName
             }
         }
     }


### PR DESCRIPTION
Added check if signtool is available else throw exception.
Use full signtool path instead of system32 shortcut.