### PR TITLE
Use Invoke-ScriptInNavContainer cmdlet.

### DIFF
--- a/Get-NAVContainerAppInfoFile.ps1
+++ b/Get-NAVContainerAppInfoFile.ps1
@@ -22,8 +22,7 @@ function Get-NavContainerAppInfoFile {
     $containerPath = Get-NavContainerPath -containerName $ContainerName -path $AppPath -throw
     #$args = @{"Path" = $containerPath}
 
-    $session = Get-NavContainerSession -containerName $ContainerName -silent
-    Invoke-Command -Session $session -ScriptBlock { Param($Path)
+    Invoke-ScriptInNavContainer -containerName $ContainerName -scriptblock { Param($Path)
         Get-NavAppInfo -Path $Path | ConvertTo-Json -Depth 2
-    } -ArgumentList $containerPath | ConvertFrom-Json
+    } -argumentList $containerPath | ConvertFrom-Json
 }

--- a/Init-ALEnvironment.ps1
+++ b/Init-ALEnvironment.ps1
@@ -167,8 +167,7 @@ function Init-ALEnvironment
     
     if ($inclTestToolkit -and $CreateTestWebServices) {
         Write-Host 'Publishing CALTestResult (PAG130405) and CALCodeCoverageMap (PAG130408) Webservices'
-        $session = Get-NavContainerSession -containerName $ContainerName -silent
-        Invoke-Command -Session $session -ScriptBlock {
+        Invoke-ScriptInNavContainer -containerName $ContainerName -scriptblock {
             New-NAVWebService  -ServerInstance NAV -ServiceName CALTestResults -ObjectType Page -ObjectId 130405 -Published $True
             New-NAVWebService  -ServerInstance NAV -ServiceName CALCodeCoverageMap -ObjectType Page -ObjectId 130408 -Published $True 
         }

--- a/Read-ALTestResult.ps1
+++ b/Read-ALTestResult.ps1
@@ -11,10 +11,8 @@ function Read-ALTestResult
         [Parameter(ValueFromPipelineByPropertyName=$True)]
         $Auth='Windows'
     )
-    $session = Get-NavContainerSession -containerName $ContainerName -silent
-    $CompanyName = Invoke-Command -Session $session `
-                   -ScriptBlock {(Get-NAVCompany -ServerInstance NAV | Select-object -First 1).CompanyName}
-    Remove-NavContainerSession -containerName $ContainerName
+    $CompanyName = Invoke-ScriptInNavContainer -containerName $ContainerName `
+                    -scriptblock {(Get-NAVCompany -ServerInstance NAV | Select-object -First 1).CompanyName} 
     Write-Host "Company name = '$CompanyName'"
 
     if ((-not $Password) -or ($Password -eq '')) {

--- a/Run-ALDevelClient.ps1
+++ b/Run-ALDevelClient.ps1
@@ -8,10 +8,8 @@ function Run-ALDevelClient
     )
 
     $params = @()
-    $session = Get-NavContainerSession -containerName $containerName -silent
-    $databaseName = Invoke-Command -Session $session `
+    $databaseName = Invoke-ScriptInNavContainer -containerName $ContainerName `
                    -ScriptBlock {$config = Get-NAVServerConfiguration -ServerInstance NAV -AsXml;$config.Configuration.appSettings.SelectSingleNode('./add[@key=''DatabaseName'']').value}
-    Remove-NavContainerSession -containerName $containerName
    
     $params += @("database=`"$databaseName`",servername=`"$ContainerName`",ID=`"$ContainerName`",generatesymbolreference=1")
     $ClientExe = Join-Path -Path $ClientPath 'finsql.exe'


### PR DESCRIPTION
Hi @kine,

I am using `navcontainerhelper\Check-NavContainerHelperPermissions -Fix` to use containers without requiring administrator permissions.

Currently `Init-ALEnvironment` and some other cmdlets are using `navcontainerhelper\Get-NavContainerSession` to return PowerShell session and then `Invoke-Command` cmdlet to invoke commands.

The problem is that `Get-NavContainerSession` cannot find running container when not running as administrator. You get error like this:
```powershell
PS C:\Users\ernjus\Desktop\TMP-ExternalDocumentNo> docker ps
CONTAINER ID        IMAGE                                                   COMMAND                  CREATED             STATUS                    PORTS                                                NAMES
d70e2173a074        mcr.microsoft.com/businesscentral/sandbox:lt-ltsc2019   "powershell -Command…"   11 minutes ago      Up 11 minutes (healthy)   80/tcp, 443/tcp, 1433/tcp, 7045-7049/tcp, 8080/tcp   BCEDN
PS C:\Users\ernjus\Desktop\TMP-ExternalDocumentNo> Get-NavContainerSession -containerName BCEDN
New-PSSession : The input ContainerId d70e2173a0742457ff4609ef932fbf6ebc66fb78ecaf8766d4f2fb1d81a8f4fd does not exist, or the corresponding container is not running.
At C:\Users\ernjus\Documents\WindowsPowerShell\Modules\navcontainerhelper\0.6.0.8\ContainerHandling\Get-NavContainerSession.ps1:37 char:24
+ ...  $session = New-PSSession -ContainerId $containerId -RunAsAdministrat ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [New-PSSession], PSInvalidOperationException
    + FullyQualifiedErrorId : CreateRemoteRunspaceForContainerFailed,Microsoft.PowerShell.Commands.NewPSSessionCommand
```

Thanks.