### PR TITLE
Sanitize file path

### DIFF
--- a/Publish-ALAppTree.ps1
+++ b/Publish-ALAppTree.ps1
@@ -27,7 +27,7 @@ function Publish-ALAppTree
     if ($App.AppPath -like '*.app') {
       $AppFile = $App.AppPath
     } else {
-      $AppFile = (Get-ChildItem -Path $PackagesPath -Filter "$($App.publisher)_$($App.name)_*.app" | Select-Object -First 1).FullName
+      $AppFile = (Get-ChildItem -Path $PackagesPath -Filter "$($App.publisher.replace('/',''))_$($App.name.replace('/',''))_*.app" | Select-Object -First 1).FullName
     }
     if (-not $AppFile) {
       Write-Host "App $($App.name) from $($App.publisher) not found."

--- a/Read-ALTestResult.ps1
+++ b/Read-ALTestResult.ps1
@@ -14,6 +14,7 @@ function Read-ALTestResult
     $CompanyName = Invoke-ScriptInNavContainer -containerName $ContainerName `
                     -scriptblock {(Get-NAVCompany -ServerInstance NAV | Select-object -First 1).CompanyName} 
     Write-Host "Company name = '$CompanyName'"
+    $CompanyName = [uri]::EscapeDataString($CompanyName)
 
     if ((-not $Password) -or ($Password -eq '')) {
         $proxy = New-WebServiceProxy -Uri "http://$($ContainerName):7047/NAV/WS/$($CompanyName)/Page/CALTestResults" -Class WS -Namespace NVRAppDevOps -UseDefaultCredential


### PR DESCRIPTION
If the app publisher or name contains a forward slash, the AL compiler removes this from the filename.
This script should follow the same behavior.